### PR TITLE
Fix underscore in #ifdef directive and add options to the CLI

### DIFF
--- a/DebugCompiler/ConditionalBlocks.cs
+++ b/DebugCompiler/ConditionalBlocks.cs
@@ -188,7 +188,7 @@ internal sealed class ConditionalBlocks
 
         tb.Append(InPlace[SourcePosition++]);
 
-        while (SourcePosition < InPlace.Length && char.IsLetterOrDigit(InPlace[SourcePosition]))
+        while (SourcePosition < InPlace.Length && (char.IsLetterOrDigit(InPlace[SourcePosition]) || InPlace[SourcePosition] == '_'))
             tb.Append(InPlace[SourcePosition++]);
 
         Token = tb.ToString().ToLower();


### PR DESCRIPTION
Hello, I've made some little changes to the code, it's one fix and some options to the CLI

I've fixed the token parser for the ConditionalBlocks.cs, before if a token was containing a `_` it stopped before and was only parsing the word, example: `#ifdef DEV_MODE` was read the same as `#ifdef DEV`.

I've also added these things to the CLI,

the option `-D{something}`, like in more common compilers, it adds the `something` to the conditional symbols, for example `-DDEV_MODE` add the symbol `DEV_MODE` without having to put it in the gsc.conf file, for me it's a plus because I don't have to remember to not push the gsc.conf file or to keep clean the script where I add my dev options.

The compiler will also return a exit code 0 or 1 depending on the error or success, with the help of the 2 new options,

- `--compile`, same as `--build`, but the compiler doesn't inject the script inside the game
- `--noupdate`, it doesn't check for an update

I would want to do a Github Workflow to compile and publish my scripts automatically with error checks.

For the 2 first ones I don't really mind because I have my own build, but for the 3rd one it would be better to have you publishing a build so the workflow would download it.