### PR TITLE
fixed typo breaking --inject argument

### DIFF
--- a/DebugCompiler/Root.cs
+++ b/DebugCompiler/Root.cs
@@ -111,7 +111,7 @@ namespace DebugCompiler
 
             if (args.Length > 2 && options.Contains("--inject"))
             {
-                return root.cmd_Inject(args, options);
+                return root.cmd_Inject(arguments, options);
             }
 
             root.AddCommand(ConsoleKey.Q, "Quit Program", root.cmd_Exit);


### PR DESCRIPTION
args[0] will always be "--inject"

this causes the file check inside of cmd_inject to fail

if(!File.Exists(args[0]))